### PR TITLE
update docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.2"
 
 services:
 


### PR DESCRIPTION
Updates docker-compose version to enable using `--build-arg` parameter. This enables container builds in enterprise environments with proxies